### PR TITLE
refactor: UUID 생성 어노테이션 교체

### DIFF
--- a/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/Category.java
+++ b/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/Category.java
@@ -2,7 +2,6 @@ package com._NT.deliveryShop.domain.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.util.UUID;
@@ -13,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.UuidGenerator;
 
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -25,7 +25,7 @@ import lombok.ToString;
 public class Category extends Timestamped {
 
     @Id
-    @GeneratedValue(generator = "uuid")
+    @UuidGenerator
     @Column(name = "category_id")
     private UUID categoryId;
 

--- a/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/DeliveryAddress.java
+++ b/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/DeliveryAddress.java
@@ -1,20 +1,25 @@
 package com._NT.deliveryShop.domain.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.GenericGenerator;
-
-import java.util.UUID;
+import org.hibernate.annotations.UuidGenerator;
 
 @Entity
 @Table(name = "p_delivery_address")
 @Getter
 @NoArgsConstructor
 public class DeliveryAddress extends Timestamped {
+
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @UuidGenerator
     @Column(name = "delivery_address_id", updatable = false, nullable = false)
     private UUID deliveryAddressId;
 

--- a/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/DeliveryInfo.java
+++ b/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/DeliveryInfo.java
@@ -1,21 +1,27 @@
 package com._NT.deliveryShop.domain.entity;
 
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.GenericGenerator;
-
-import java.util.UUID;
+import org.hibernate.annotations.UuidGenerator;
 
 @Entity
 @Table(name = "p_delivery_info")
 @Getter
 @NoArgsConstructor
 public class DeliveryInfo extends Timestamped {
+
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @UuidGenerator
     @Column(name = "delivery_info_id", updatable = false, nullable = false)
     private UUID deliveryInfoId;
 

--- a/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/Order.java
+++ b/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/Order.java
@@ -1,22 +1,31 @@
 package com._NT.deliveryShop.domain.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.util.List;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.GenericGenerator;
-
-import java.util.List;
-import java.util.UUID;
+import org.hibernate.annotations.UuidGenerator;
 
 @Entity
 @Table(name = "p_order")
 @Getter
 @NoArgsConstructor
 public class Order extends Timestamped {
+
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @UuidGenerator
     @Column(name = "order_id", updatable = false, nullable = false)
     private UUID orderId;
 
@@ -48,7 +57,8 @@ public class Order extends Timestamped {
     @OneToMany(mappedBy = "order")
     private List<OrderProduct> orderProducts;
 
-    public Order(User user, Restaurant restaurant, Payment payment, DeliveryInfo deliveryInfo, OrderStatus status, Boolean isOnline) {
+    public Order(User user, Restaurant restaurant, Payment payment, DeliveryInfo deliveryInfo,
+        OrderStatus status, Boolean isOnline) {
         this.user = user;
         this.restaurant = restaurant;
         this.payment = payment;
@@ -56,7 +66,8 @@ public class Order extends Timestamped {
         this.status = status;
         this.isOnline = isOnline;
         // 연관관계 설정
-        if (payment != null) setPayment(payment);
+        if (payment != null)
+            setPayment(payment);
     }
 
     public void setPayment(Payment payment) {

--- a/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/OrderProduct.java
+++ b/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/OrderProduct.java
@@ -1,20 +1,25 @@
 package com._NT.deliveryShop.domain.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.GenericGenerator;
-
-import java.util.UUID;
+import org.hibernate.annotations.UuidGenerator;
 
 @Entity
 @Table(name = "p_order_product")
 @Getter
 @NoArgsConstructor
 public class OrderProduct extends Timestamped {
+
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @UuidGenerator
     @Column(name = "order_product_id")
     private UUID orderProductId;
 

--- a/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/Payment.java
+++ b/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/Payment.java
@@ -1,20 +1,28 @@
 package com._NT.deliveryShop.domain.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.GenericGenerator;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
 
 @Entity
 @Table(name = "p_payment")
 @Getter
 @NoArgsConstructor
 public class Payment extends Timestamped {
+
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @UuidGenerator
     @Column(name = "payment_id", updatable = false, nullable = false)
     private UUID paymentId;
 
@@ -45,7 +53,7 @@ public class Payment extends Timestamped {
     public void modifyPayment(int amount) {
         this.amount = amount;
     }
-  
+
     // 연관관계 편의 메서드
     public void setOrder(Order order) {
         this.order = order;

--- a/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/Product.java
+++ b/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/Product.java
@@ -3,7 +3,6 @@ package com._NT.deliveryShop.domain.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -16,7 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.With;
-import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.UuidGenerator;
 
 
 @With
@@ -27,9 +26,9 @@ import org.hibernate.annotations.GenericGenerator;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product extends Timestamped {
+
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @UuidGenerator
     @Column(name = "product_id", updatable = false, nullable = false)
     private UUID productId;
 

--- a/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/Restaurant.java
+++ b/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/domain/entity/Restaurant.java
@@ -4,7 +4,6 @@ package com._NT.deliveryShop.domain.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -19,7 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.With;
-import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.UuidGenerator;
 
 @With
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,9 +29,9 @@ import org.hibernate.annotations.GenericGenerator;
 @Getter
 @Setter
 public class Restaurant extends Timestamped {
+
     @Id
-    @GeneratedValue(generator = "UUID")
-    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @UuidGenerator
     @Column(name = "restaurant_id", updatable = false, nullable = false)
     private UUID restaurantId;
 


### PR DESCRIPTION
## 작업 요약

GenericGenerator 어노테이션 지원 종료에 따른 UuidGenerator 어노테이션을 사용하는 방식으로 변경

## PR 체크리스트
- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 develop 브랜치를 merge 하였는가?


## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [ ] 신규 기능
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 기타

## 작업 상세 내용
- GenericGenerator 사용 어노테이션을 UuidGenerator 어노테이션을 사용하도록 수정

## 참고
- [GenericGenerator 의 Deprecated 문서](https://docs.jboss.org/hibernate/orm/6.5/javadocs/org/hibernate/annotations/GenericGenerator.html)
- [GenericGenerator -> IdGeneratorType 로 의 변경 내역](https://docs.jboss.org/hibernate/orm/6.5/javadocs/org/hibernate/annotations/IdGeneratorType.html)

## 다음 할 일


## 질문 사항


**💬질문 내용**


**🔴 이건 반드시 확인해 주세요!**
