### PR TITLE
fix: AuthInspector의 ADMIN ROLE 의 잘못된 String 값 입력 수정

### DIFF
--- a/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/service/authorizer/AuthenticationInspector.java
+++ b/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/service/authorizer/AuthenticationInspector.java
@@ -1,5 +1,7 @@
 package com._NT.deliveryShop.service.authorizer;
 
+import static com._NT.deliveryShop.domain.entity.UserRoleEnum.Authority.ADMIN;
+
 import com._NT.deliveryShop.domain.entity.User;
 import com._NT.deliveryShop.repository.UserRepository;
 import com._NT.deliveryShop.repository.helper.ServiceErrorHelper;
@@ -29,7 +31,7 @@ public record AuthenticationInspector(
             throw errorHelper.unauthorized("Not authenticated");
         }
         return authentication.getAuthorities().stream()
-            .anyMatch(authority -> authority.getAuthority().equals("ADMIN"));
+            .anyMatch(authority -> authority.getAuthority().equals(ADMIN));
     }
 
 }


### PR DESCRIPTION
잘못 기입된 ADMIN ROLE 을 나타내는 값ㅇ르 값을 UserRoleEnum.Authority 의 상수를 사용하여 수정
 - "ADMIN" -> "ROLE_ADMIN"

## PR 체크리스트
- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 develop 브랜치를 merge 하였는가?


## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [ ] 신규 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 작업 상세 내용
- AuthInspector의 ADMIN ROLE 의 잘못된 String 값 입력 수정
  - "ADMIN" -> "ROLE_ADMIN" (상수)

## 다음 할 일


## 질문 사항


**💬질문 내용**


**🔴 이건 반드시 확인해 주세요!**
