### PR TITLE
fix: restaurant soft delete 상태가 category 와 product 에게 전파되지 않는 오류

### DIFF
--- a/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/repository/CategoryRepository.java
+++ b/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/repository/CategoryRepository.java
@@ -1,11 +1,20 @@
 package com._NT.deliveryShop.repository;
 
 import com._NT.deliveryShop.domain.entity.Category;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, UUID> {
 
+    @Modifying
+    @Query(
+        "UPDATE Category c SET c.isDeleted = true, c.deletedAt = :deletedAt, c.deletedBy = :deletedBy "
+            +
+            "WHERE c.categoryId = :categoryId")
+    void softDeleteCategory(UUID categoryId, LocalDateTime deletedAt, Long deletedBy);
 }

--- a/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/repository/ProductRepository.java
+++ b/com.3NT.deliveryShop/src/main/java/com/_NT/deliveryShop/repository/ProductRepository.java
@@ -20,5 +20,13 @@ public interface ProductRepository extends JpaRepository<Product, UUID> {
             "WHERE p.productId = :productId")
     void softDeleteProduct(UUID productId, LocalDateTime deletedAt, Long deletedBy);
 
+    @Modifying
+    @Query(
+        "UPDATE Product p SET p.isDeleted = true, p.deletedAt = :deletedAt, p.deletedBy = :deletedBy "
+            +
+            "WHERE p.restaurant.restaurantId = :restaurantId")
+    void softDeleteProductsByRestaurantId(UUID restaurantId, LocalDateTime deletedAt,
+        Long deletedBy);
+
     Page<Product> findAllByIsDeletedFalse(Pageable pageable);
 }


### PR DESCRIPTION
## 이슈 번호

 Issue📌: #54 

## PR 체크리스트
- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 develop 브랜치를 merge 하였는가?


## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [x] 신규 기능
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 작업 상세 내용
- 필드값을 변경하여 삭제를 구현한 softDeleteCategory 구현
- 특정 Restaurant 과 연관관계를 맺는 모든 Product 에 대한 soft delete 기능 구현
- 특정 Restaurant 과 연관관계를 맺는 모든 Product 와 Category 에 대한 soft delete 전파 기능 추가
  - 현재 Category 엔티티는 Restaurant 엔티티가 소유하는 개념이기 때문에 생명주기가 공유되어야 함
    - 같은 name 의 Category 라도 서로 다른 Restaurant 라면 서로 다른 엔티티의 Category 를 사용

## 다음 할 일


## 질문 사항


**💬질문 내용**


**🔴 이건 반드시 확인해 주세요!**
